### PR TITLE
feat: add Longbridge OAuth authentication

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -70,7 +70,7 @@ The shipped application is served by `rust-backend/`.
 ```mermaid
 flowchart LR
   A["ThetaData Parquet<br/>historical replay"] --> R["Rust analytics server"]
-  B["Longbridge Rust SDK<br/>live quote and paper account"] --> R
+  B["Longbridge OAuth / Rust SDK<br/>live quote and paper account"] --> R
   R --> C["BSM / Greeks / SVI"]
   R --> D["Surface / GEX / volatility context"]
   R --> E["Strategy risk and paper-order gates"]
@@ -94,7 +94,7 @@ trust flows.
 - Node.js 22 and npm
 - Python 3.11+ only if running the legacy parity tests
 - a licensed replay dataset for historical mode
-- optional Longbridge OpenAPI credentials for live mode
+- optional Longbridge OAuth Client ID or OpenAPI credentials for live mode
 
 ### Local
 
@@ -157,14 +157,19 @@ licensing constraints are documented in
 ## Live Mode
 
 1. Open the workstation and select **Live**.
-2. Open the connection dialog.
-3. Enter the Longbridge app key, app secret, and access token.
+2. Open the connection dialog and prefer **Longbridge OAuth 2.0**: enter the
+   registered OAuth Client ID, open the authorization page, and complete the
+   provider consent flow in the browser.
+3. If OAuth is not available for the application, enter the Longbridge app key,
+   app secret, and access token as a compatibility fallback.
 4. Connect, select an underlying and expiry, and wait for quality gates.
 
-Credentials are sent only to the same-origin Rust API and held in SDK contexts
-in process memory. They are never returned to the browser, persisted in local
-storage, written to the repository, or accepted by audit records. Disconnecting
-or stopping the process clears the in-memory session.
+The local OAuth callback listens on `127.0.0.1:60355`. Credentials are sent
+only to the same-origin Rust API and held in SDK contexts in process memory.
+They are never returned to the browser, persisted in local storage, written to
+the repository, or accepted by audit records. Disconnecting or stopping the
+process clears the in-memory session. OAuth is provider authorization, not
+application-user authentication.
 
 Do not expose the service to a network without adding authentication, TLS,
 origin restrictions, and host-level access controls. The default binding is
@@ -213,6 +218,8 @@ credentials through the local same-origin connection dialog only.
 | `/api/chain` | `GET` | Historical executable-price chain and quality gates |
 | `/api/surface` | `GET` | Historical constrained surface and trust report |
 | `/api/volatility-context` | `GET` | Point-in-time IV/RV/VRP/expected move |
+| `/api/oauth/start` | `POST` | Start a Longbridge OAuth provider authorization flow |
+| `/api/oauth/status` | `GET` | Poll OAuth flow state without exposing tokens |
 | `/api/live/session` | `POST`, `DELETE` | Configure or disconnect live SDK session |
 | `/api/live/snapshot` | `GET` | Current normalized live snapshot |
 | `/api/live/stream` | `WS` | Throttled live snapshot stream |

--- a/README.md
+++ b/README.md
@@ -312,13 +312,17 @@ data/
 ## 实时连接
 
 1. 进入工作台并切换到“实时”。
-2. 打开连接面板。
-3. 填入 Longbridge App Key、App Secret 和 Access Token。
+2. 打开连接面板，优先使用 **Longbridge OAuth 2.0**：输入已经注册的 OAuth Client ID，点击开始授权，在浏览器中完成 Longbridge 授权，再回到工作台等待连接状态变为已连接。
+3. 如果当前应用没有 OAuth Client ID，也可以使用兼容模式，填入 Longbridge App Key、App Secret 和 Access Token。
 4. 连接后选择标的与到期日，等待质量门禁通过。
 
-凭证只发送给同源 Rust API，并由 SDK Context 保存在进程内存中。服务不会把凭证
-返回浏览器、写进 localStorage、提交到审计记录或保存到仓库。断开连接或停止进程
+OAuth 回调默认监听本机 `127.0.0.1:60355`。两种认证方式都只把凭证交给同源 Rust API，
+由 Longbridge SDK Context 保存在进程内存中；OAuth Token 不会返回浏览器、写进
+localStorage、提交到审计记录、写入默认 Token 文件或保存到仓库。断开连接或停止进程
 后，内存会话即被清除。
+
+OAuth 是 Longbridge 的**提供商授权方式**，不是本项目的多用户登录系统。服务仍然默认
+只监听本机回环地址，不要把本服务直接暴露到公网。
 
 不要直接把本服务暴露到公网。默认只监听本机回环地址；若确需网络访问，必须先补充
 身份认证、TLS、Origin 限制和主机访问控制。

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,31 @@
 
 Option Workstation exposes a local HTTP API on the configured loopback port.
 The API is intended for the bundled frontend and local research automation; it
-is not an authenticated public service.
+does not provide application-user authentication. Longbridge OAuth below is
+provider authorization for the local live-data connection, not public user
+login.
+
+## Longbridge OAuth 2.0
+
+`POST /api/oauth/start` starts a browser-based Longbridge authorization flow.
+The request body is:
+
+```json
+{"client_id":"your-longbridge-oauth-client-id"}
+```
+
+The response contains a flow status and, once the local callback server is
+ready, an `authorization_url`. It never contains an access token. The browser
+should open that URL in a new tab and poll the status endpoint:
+
+`GET /api/oauth/status`
+
+The status is one of `idle`, `pending`, `connecting`, `connected`, or `error`.
+The OAuth callback listens on `127.0.0.1:60355` and the token is held only by
+the in-process SDK configuration. Tokens are not written to the OAuth crate's
+default file storage. Starting a new flow or disconnecting cancels a pending
+flow. This mechanism does not add authentication or authorization to the
+HTTP API, so public or multi-user deployments remain unsupported.
 
 ## Point-in-time replay snapshot
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -44,6 +44,9 @@ supply chain are separate trust boundaries.
 
 - loopback-only default binding;
 - same-origin credential flow and process-memory SDK contexts;
+- Longbridge OAuth authorization-code flow with a process-memory token store;
+- OAuth status responses expose only flow metadata and an authorization URL,
+  never an access or refresh token;
 - credential-field rejection in audit payloads;
 - explicit request bounds and typed request models;
 - paper-account recognition, server enablement, freshness, and typed
@@ -64,7 +67,8 @@ The project does not currently secure:
 - hostile provider or exchange infrastructure;
 - real-money automated trading.
 
-Such deployments need authentication, TLS, CSRF/origin controls, authorization,
+Longbridge OAuth is provider authorization only; it does not authenticate users
+to this HTTP service. Such deployments need application authentication, TLS, CSRF/origin controls, authorization,
 rate limiting, external secret storage, hardened logging, and independent
 security review.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -99,9 +99,11 @@ function App() {
   const [workspaceId, setWorkspaceId] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
-  const [connection, setConnection] = useState({ connected: false, state: 'disconnected', packages: [], subscribed_contracts: 0 })
+  const [connection, setConnection] = useState({ connected: false, state: 'disconnected', auth_method: 'none', packages: [], subscribed_contracts: 0 })
   const [credentialOpen, setCredentialOpen] = useState(false)
   const [credentials, setCredentials] = useState({ app_key: '', app_secret: '', access_token: '' })
+  const [oauthClientId, setOauthClientId] = useState('')
+  const [oauthStatus, setOauthStatus] = useState({ status: 'idle', flow_id: null, client_id: null, authorization_url: null, error: null })
   const [liveSymbolDraft, setLiveSymbolDraft] = useState('SPY')
   const [liveFeed, setLiveFeed] = useState(null)
   const [liveSocketState, setLiveSocketState] = useState('idle')
@@ -146,13 +148,40 @@ function App() {
   }, [connection.connected, connection.trade_connected])
 
   useEffect(() => {
-    Promise.all([api('/api/catalog'), api('/api/connection')]).then(([data, status]) => {
+    Promise.all([api('/api/catalog'), api('/api/connection'), api('/api/oauth/status')]).then(([data, status, oauth]) => {
       setCatalog(data)
       setConnection(status)
+      setOauthStatus(oauth)
       setTradingDate(data.common_dates.at(-1) || '')
     }).catch((reason) => setError(reason.message))
     refreshAudit().catch((reason) => setError(reason.message))
   }, [refreshAudit])
+
+  useEffect(() => {
+    if (!['pending', 'connecting'].includes(oauthStatus.status)) return undefined
+    let active = true
+    const poll = async () => {
+      try {
+        const status = await api('/api/oauth/status')
+        if (!active) return
+        setOauthStatus(status)
+        if (status.status === 'connected') {
+          setConnection(await api('/api/connection'))
+        }
+      } catch (reason) {
+        if (active) setError(reason.message)
+      }
+    }
+    const timer = window.setInterval(poll, 1000)
+    return () => {
+      active = false
+      window.clearInterval(timer)
+    }
+  }, [oauthStatus.status])
+
+  useEffect(() => {
+    if (oauthStatus.status === 'error' && oauthStatus.error) setError(oauthStatus.error)
+  }, [oauthStatus.status, oauthStatus.error])
 
   useEffect(() => {
     localStorage.setItem('option-workstation-layout', layout)
@@ -261,6 +290,20 @@ function App() {
     }
   }
 
+  const startOAuth = async (event) => {
+    event.preventDefault()
+    setLoading(true)
+    setError('')
+    try {
+      const status = await apiJson('/api/oauth/start', 'POST', { client_id: oauthClientId.trim() })
+      setOauthStatus(status)
+    } catch (reason) {
+      setError(reason.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const disconnectLongbridge = async () => {
     try {
       const pending = liveRequestRef.current
@@ -271,6 +314,7 @@ function App() {
       setLiveSwitch(null)
       const status = await apiJson('/api/connection', 'DELETE')
       setConnection(status)
+      setOauthStatus(await api('/api/oauth/status'))
       liveSequenceRef.current = -1
       setLiveFeed(null)
       setLiveSocketState('idle')
@@ -980,9 +1024,21 @@ function App() {
           <div className="credential-header"><div><KeyRound size={18} /><div><strong id="credential-title">Longbridge OpenAPI</strong><span>实时行情连接</span></div></div><button className="drawer-close" title="关闭" onClick={() => setCredentialOpen(false)}><X size={17} /></button></div>
           <div className={`connection-summary ${connection.connected ? 'connected' : ''}`}>
             {connection.connected ? <Wifi size={17} /> : <WifiOff size={17} />}
-            <div><strong>{connection.connected ? `已连接 ${connection.account_hint || ''}` : '尚未连接'}</strong><span>{quotePermission} · {connection.state}</span></div>
+            <div><strong>{connection.connected ? `已连接 ${connection.account_hint || ''}` : '尚未连接'}</strong><span>{quotePermission} · {connection.state} · {connection.auth_method === 'oauth' ? 'OAuth 2.0' : connection.auth_method === 'apikey' ? 'API Key' : '未认证'}</span></div>
           </div>
           {connection.connected && <div className="trade-connection-grid"><div><span>Trade API</span><b>{connection.trade_connected ? 'Connected' : 'Unavailable'}</b></div><div><span>Account</span><b>{connection.account_type || '--'}</b></div><div><span>Buying Power</span><b>{connection.buy_power || '--'}</b></div><div><span>Paper Orders</span><b className={connection.order_execution_enabled ? 'ok-text' : 'warning-text'}>{connection.order_execution_enabled ? 'Enabled' : 'Locked'}</b></div></div>}
+          <section className="oauth-section" aria-labelledby="oauth-title">
+            <div className="oauth-heading"><div><Radio size={15} /><strong id="oauth-title">Longbridge OAuth 2.0</strong></div><span>推荐</span></div>
+            <p>使用浏览器完成授权，不需要在工作台输入 App Secret。Access Token 只驻留 Rust 进程内存，不写入浏览器存储或本地文件。</p>
+            <form className="oauth-form" onSubmit={startOAuth} autoComplete="off">
+              <label htmlFor="lb-oauth-client-id"><span>OAuth Client ID / App Key</span><input id="lb-oauth-client-id" type="text" autoComplete="off" placeholder="输入 Longbridge OAuth Client ID" value={oauthClientId} onChange={(event) => setOauthClientId(event.target.value)} /></label>
+              <button className="oauth-button" type="submit" disabled={loading || ['pending', 'connecting'].includes(oauthStatus.status)}><Radio size={14} />{oauthStatus.status === 'connecting' ? '正在建立连接' : oauthStatus.status === 'pending' ? '等待浏览器授权' : '开始 OAuth 授权'}</button>
+            </form>
+            {oauthStatus.authorization_url && <div className="oauth-status"><span>授权页面已准备好</span><a className="oauth-link" href={oauthStatus.authorization_url} target="_blank" rel="noreferrer">打开授权页面</a></div>}
+            {oauthStatus.status === 'pending' && <div className="oauth-status muted">完成授权后此窗口会自动验证连接；不要关闭本地服务。</div>}
+            {oauthStatus.status === 'connected' && <div className="oauth-status success">OAuth 已连接，可开始实时会话。</div>}
+            {oauthStatus.status === 'error' && oauthStatus.error && <div className="oauth-status failure">{oauthStatus.error}</div>}
+          </section>
           <form className="credential-form" onSubmit={submitCredentials} autoComplete="off">
             <label htmlFor="lb-app-key"><span>App Key</span><input id="lb-app-key" type="password" autoComplete="new-password" value={credentials.app_key} onChange={(event) => setCredentials((current) => ({ ...current, app_key: event.target.value }))} /></label>
             <label htmlFor="lb-app-secret"><span>App Secret</span><input id="lb-app-secret" type="password" autoComplete="new-password" value={credentials.app_secret} onChange={(event) => setCredentials((current) => ({ ...current, app_secret: event.target.value }))} /></label>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -246,6 +246,13 @@ tr.focused { background: #18272e; }
 .trade-connection-grid { display: grid; grid-template-columns: 1fr 1fr; margin: -4px 0 16px; border-top: 1px solid #26323b; border-left: 1px solid #26323b; }
 .trade-connection-grid > div { min-width: 0; display: grid; gap: 4px; padding: 8px 9px; border-right: 1px solid #26323b; border-bottom: 1px solid #26323b; }
 .trade-connection-grid span { color: #687782; font-size: 8px; }.trade-connection-grid b { overflow: hidden; color: #b9c5ce; font-size: 10px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.oauth-section { display: grid; gap: 10px; margin-bottom: 18px; padding: 12px; border: 1px solid #2c5f55; background: #10201d; }
+.oauth-heading { display: flex; align-items: center; justify-content: space-between; }
+.oauth-heading > div { display: flex; align-items: center; gap: 7px; }.oauth-heading svg { color: #54d6b6; }.oauth-heading strong { color: #d5e4e1; font-size: 11px; }.oauth-heading > span { padding: 3px 5px; border: 1px solid #397d6c; color: #75dbc2; font-size: 8px; }
+.oauth-section p { margin: 0; color: #9aaba8; font-size: 9px; line-height: 1.55; }
+.oauth-form { display: grid; gap: 9px; }.oauth-form label { display: grid; gap: 5px; }.oauth-form label > span { color: #91a39f; font-size: 9px; }.oauth-form input { width: 100%; height: 32px; padding: 0 8px; border: 1px solid #31584f; border-radius: 3px; outline: 0; background: #0c1715; color: #d5e5e1; font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; }.oauth-form input:focus { border-color: #54d6b6; box-shadow: 0 0 0 2px #245c5038; }
+.oauth-button { min-height: 32px; display: flex; align-items: center; justify-content: center; gap: 6px; border: 1px solid #3d9f89; border-radius: 3px; background: #267d6b; color: #f1fffb; font-size: 10px; font-weight: 650; }.oauth-button:disabled { cursor: wait; opacity: .65; }
+.oauth-status { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: #b9c8c4; font-size: 9px; line-height: 1.5; }.oauth-status.muted { display: block; color: #9d9e88; }.oauth-status.success { display: block; color: #69d6bd; }.oauth-status.failure { display: block; padding: 7px 8px; border-left: 2px solid #df8c95; color: #ff9aa4; background: #211417; }.oauth-link { color: #75dbc2; font-weight: 650; text-decoration: underline; text-underline-offset: 2px; }
 .credential-form { display: grid; gap: 12px; }
 .credential-form > label { display: grid; gap: 5px; }
 .credential-form > label > span, .package-section > span { color: #8997a1; font-size: 10px; font-weight: 600; }

--- a/rust-backend/src/live.rs
+++ b/rust-backend/src/live.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashSet,
     env,
     sync::{
-        Arc,
+        Arc, Mutex as StdMutex,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -15,6 +15,7 @@ use chrono_tz::America::New_York;
 use dashmap::DashMap;
 use longbridge::{
     Config,
+    oauth::{OAuth, OAuthBuilder, OAuthError, OAuthResult, StoredToken, TokenStorage},
     quote::{
         AdjustType, Candlestick, Period, PushEvent, PushEventDetail, QuoteContext, StrikePriceInfo,
         SubFlags, TradeSessions,
@@ -26,13 +27,16 @@ use longbridge::{
 };
 use rust_decimal::prelude::ToPrimitive;
 use serde_json::{Value, json};
-use tokio::sync::{Mutex, RwLock, broadcast};
+use tokio::{
+    sync::{Mutex, RwLock, broadcast},
+    task::JoinHandle,
+};
 
 use crate::{
     analytics::{ChainBuild, build_chain, build_surface},
     models::{
         Bar, ConnectionStatus, CredentialRequest, LiveFeedInfo, LiveSessionRequest, LiveSnapshot,
-        RawOptionQuote,
+        OAuthStatus, RawOptionQuote,
     },
     strategy::ExecutionLeg,
 };
@@ -42,6 +46,28 @@ const OPENAPI_SUBSCRIPTION_LIMIT: usize = 500;
 const RESERVED_SUBSCRIPTIONS: usize = 20;
 const OPTION_REQUEST_COOLDOWN: Duration = Duration::from_secs(65);
 const OPTION_RETRY_MARKER: &str = "option_retry_after_ms=";
+const OAUTH_CALLBACK_PORT: u16 = 60355;
+const OAUTH_URL_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Default)]
+struct MemoryTokenStorage {
+    token: Arc<StdMutex<Option<StoredToken>>>,
+}
+
+impl TokenStorage for MemoryTokenStorage {
+    fn load(&self, _client_id: &str) -> Option<StoredToken> {
+        self.token.lock().ok()?.clone()
+    }
+
+    fn save(&self, token: &StoredToken) -> OAuthResult<()> {
+        let mut stored = self
+            .token
+            .lock()
+            .map_err(|_| OAuthError::Other("OAuth token storage lock poisoned".into()))?;
+        *stored = Some(token.clone());
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone)]
 struct TopOfBook {
@@ -123,6 +149,12 @@ struct ManagerState {
     status: ConnectionStatus,
 }
 
+#[derive(Default)]
+struct OAuthFlowState {
+    status: OAuthStatus,
+    task: Option<JoinHandle<()>>,
+}
+
 pub struct LiveManager {
     state: RwLock<ManagerState>,
     session_setup: Mutex<()>,
@@ -131,6 +163,8 @@ pub struct LiveManager {
     events: broadcast::Sender<u64>,
     sequence: AtomicU64,
     refresh_started: AtomicBool,
+    oauth_sequence: AtomicU64,
+    oauth_flow: Mutex<OAuthFlowState>,
     snapshot_cache: Mutex<Option<(u64, LiveSnapshot)>>,
     risk_free_rate: f64,
     paper_execution_requested: bool,
@@ -147,6 +181,8 @@ impl LiveManager {
             events,
             sequence: AtomicU64::new(0),
             refresh_started: AtomicBool::new(false),
+            oauth_sequence: AtomicU64::new(0),
+            oauth_flow: Mutex::new(OAuthFlowState::default()),
             snapshot_cache: Mutex::new(None),
             risk_free_rate,
             paper_execution_requested: env::var("OPTION_WORKSTATION_PAPER_ORDER_EXECUTION")
@@ -196,6 +232,10 @@ impl LiveManager {
 
     pub async fn status(&self) -> ConnectionStatus {
         self.state.read().await.status.clone()
+    }
+
+    pub async fn oauth_status(&self) -> OAuthStatus {
+        self.oauth_flow.lock().await.status.clone()
     }
 
     pub async fn daily_closes(&self, count: usize) -> anyhow::Result<Vec<(String, f64)>> {
@@ -465,23 +505,135 @@ impl LiveManager {
         });
     }
 
-    pub async fn connect(
+    async fn cancel_oauth_flow(&self) {
+        let mut flow = self.oauth_flow.lock().await;
+        if let Some(task) = flow.task.take() {
+            task.abort();
+        }
+        flow.status = OAuthStatus::default();
+    }
+
+    async fn finish_oauth(self: Arc<Self>, flow_id: String, result: OAuthResult<OAuth>) {
+        {
+            let mut flow = self.oauth_flow.lock().await;
+            if flow.status.flow_id.as_deref() != Some(flow_id.as_str()) {
+                return;
+            }
+            flow.status.status = "connecting".into();
+            flow.status.authorization_url = None;
+            flow.status.error = None;
+        }
+
+        let outcome = match result {
+            Ok(oauth) => self.connect_oauth(oauth).await,
+            Err(error) => Err(anyhow!("Longbridge OAuth 授权失败: {error}")),
+        };
+
+        let mut flow = self.oauth_flow.lock().await;
+        if flow.status.flow_id.as_deref() != Some(flow_id.as_str()) {
+            return;
+        }
+        match outcome {
+            Ok(_) => {
+                flow.status.status = "connected".into();
+                flow.status.error = None;
+            }
+            Err(error) => {
+                flow.status.status = "error".into();
+                flow.status.error = Some(format!("{error:#}"));
+            }
+        }
+    }
+
+    pub async fn start_oauth(self: &Arc<Self>, client_id: String) -> anyhow::Result<OAuthStatus> {
+        let client_id = client_id.trim().to_string();
+        anyhow::ensure!(!client_id.is_empty(), "OAuth Client ID 不能为空");
+        anyhow::ensure!(
+            client_id.len() <= 256
+                && client_id.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.' | ':')
+                }),
+            "OAuth Client ID 格式异常"
+        );
+
+        let mut flow = self.oauth_flow.lock().await;
+        if matches!(flow.status.status.as_str(), "pending" | "connecting") {
+            return Ok(flow.status.clone());
+        }
+        if let Some(task) = flow.task.take() {
+            task.abort();
+        }
+
+        let flow_id = format!(
+            "oauth-{}",
+            self.oauth_sequence.fetch_add(1, Ordering::Relaxed) + 1
+        );
+        let (url_sender, url_receiver) = tokio::sync::oneshot::channel::<String>();
+        let url_sender = Arc::new(StdMutex::new(Some(url_sender)));
+        let manager = Arc::clone(self);
+        let task_flow_id = flow_id.clone();
+        let task_client_id = client_id.clone();
+        let task_url_sender = Arc::clone(&url_sender);
+        let task = tokio::spawn(async move {
+            let storage = MemoryTokenStorage::default();
+            let result = OAuthBuilder::new(task_client_id)
+                .callback_port(OAUTH_CALLBACK_PORT)
+                .token_storage(storage)
+                .build(move |url| {
+                    if let Ok(mut sender) = task_url_sender.lock()
+                        && let Some(sender) = sender.take()
+                    {
+                        let _ = sender.send(url.to_string());
+                    }
+                })
+                .await;
+            manager.finish_oauth(task_flow_id, result).await;
+        });
+        flow.status = OAuthStatus {
+            status: "pending".into(),
+            flow_id: Some(flow_id),
+            client_id: Some(client_id),
+            authorization_url: None,
+            error: None,
+        };
+        flow.task = Some(task);
+        drop(flow);
+
+        if let Ok(Ok(authorization_url)) =
+            tokio::time::timeout(OAUTH_URL_TIMEOUT, url_receiver).await
+        {
+            let mut flow = self.oauth_flow.lock().await;
+            if flow.status.status == "pending" {
+                flow.status.authorization_url = Some(authorization_url);
+            }
+        }
+        Ok(self.oauth_status().await)
+    }
+
+    async fn connect_oauth(self: &Arc<Self>, oauth: OAuth) -> anyhow::Result<ConnectionStatus> {
+        let access_token = oauth
+            .access_token()
+            .await
+            .context("Longbridge OAuth token unavailable")?;
+        let account_type = token_account_type(&access_token);
+        let config = Arc::new(Config::from_oauth(oauth));
+        self.connect_with_config(config, account_type, "oauth")
+            .await
+    }
+
+    async fn connect_with_config(
         self: &Arc<Self>,
-        credentials: CredentialRequest,
+        config: Arc<Config>,
+        token_account_type: Option<String>,
+        auth_method: &str,
     ) -> anyhow::Result<ConnectionStatus> {
-        credentials.validate().map_err(|message| anyhow!(message))?;
-        let token_account_type = token_account_type(&credentials.access_token);
         {
             let mut state = self.state.write().await;
             state.status.state = "connecting".into();
+            state.status.auth_method = auth_method.into();
             state.status.switch_state = "connecting".into();
             state.status.error = None;
         }
-        let config = Arc::new(Config::from_apikey(
-            credentials.app_key.trim(),
-            credentials.app_secret.trim(),
-            credentials.access_token.trim(),
-        ));
         let (quote, mut receiver) = QuoteContext::new(Arc::clone(&config));
         let (trade, mut trade_receiver) = TradeContext::new(config);
         let validation = async {
@@ -570,6 +722,7 @@ impl LiveManager {
         let status = ConnectionStatus {
             connected: true,
             state: "connected".into(),
+            auth_method: auth_method.into(),
             account_hint: Some(hint),
             quote_level: Some(quote_level),
             packages,
@@ -604,7 +757,24 @@ impl LiveManager {
         Ok(status)
     }
 
+    pub async fn connect(
+        self: &Arc<Self>,
+        credentials: CredentialRequest,
+    ) -> anyhow::Result<ConnectionStatus> {
+        credentials.validate().map_err(|message| anyhow!(message))?;
+        self.cancel_oauth_flow().await;
+        let token_account_type = token_account_type(&credentials.access_token);
+        let config = Arc::new(Config::from_apikey(
+            credentials.app_key.trim(),
+            credentials.app_secret.trim(),
+            credentials.access_token.trim(),
+        ));
+        self.connect_with_config(config, token_account_type, "apikey")
+            .await
+    }
+
     pub async fn disconnect(&self) -> ConnectionStatus {
+        self.cancel_oauth_flow().await;
         let mut state = self.state.write().await;
         state.engine = None;
         state.active = None;

--- a/rust-backend/src/main.rs
+++ b/rust-backend/src/main.rs
@@ -30,7 +30,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use crate::{
     audit::{AuditCaptureRequest, AuditStore},
     live::{LiveManager, option_retry_after_ms},
-    models::{CredentialRequest, LiveSessionRequest},
+    models::{CredentialRequest, LiveSessionRequest, OAuthStartRequest},
     replay::{ReplaySnapshotParams, ReplayStore},
     strategy::{PaperOrderRequest, StrategyRequest, analyze_strategy},
 };
@@ -293,6 +293,24 @@ async fn replay_snapshot(
 
 async fn connection_status(State(state): State<AppState>) -> Json<Value> {
     Json(serde_json::to_value(state.live.status().await).expect("serialize connection status"))
+}
+
+async fn oauth_status(State(state): State<AppState>) -> Json<Value> {
+    Json(serde_json::to_value(state.live.oauth_status().await).expect("serialize OAuth status"))
+}
+
+async fn start_oauth(
+    State(state): State<AppState>,
+    Json(request): Json<OAuthStartRequest>,
+) -> Result<Json<Value>, ApiError> {
+    request.validate().map_err(ApiError::bad_request)?;
+    state
+        .live
+        .start_oauth(request.client_id)
+        .await
+        .and_then(|value| serde_json::to_value(value).map_err(anyhow::Error::from))
+        .map(Json)
+        .map_err(ApiError::upstream)
 }
 
 async fn connect_longbridge(
@@ -611,6 +629,8 @@ fn app(state: AppState, frontend_dist: PathBuf) -> Router {
                 .post(connect_longbridge)
                 .delete(disconnect_longbridge),
         )
+        .route("/api/oauth/status", get(oauth_status))
+        .route("/api/oauth/start", post(start_oauth))
         .route("/api/live/session", post(setup_live_session))
         .route("/api/live/snapshot", get(live_snapshot))
         .route("/api/live/volatility-context", get(live_volatility_context))

--- a/rust-backend/src/models.rs
+++ b/rust-backend/src/models.rs
@@ -285,10 +285,54 @@ impl CredentialRequest {
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct OAuthStartRequest {
+    pub client_id: String,
+}
+
+impl OAuthStartRequest {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        let client_id = self.client_id.trim();
+        if client_id.is_empty() {
+            return Err("OAuth Client ID 不能为空");
+        }
+        if client_id.len() > 256
+            || !client_id.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.' | ':')
+            })
+        {
+            return Err("OAuth Client ID 格式异常");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OAuthStatus {
+    pub status: String,
+    pub flow_id: Option<String>,
+    pub client_id: Option<String>,
+    pub authorization_url: Option<String>,
+    pub error: Option<String>,
+}
+
+impl Default for OAuthStatus {
+    fn default() -> Self {
+        Self {
+            status: "idle".into(),
+            flow_id: None,
+            client_id: None,
+            authorization_url: None,
+            error: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ConnectionStatus {
     pub connected: bool,
     pub state: String,
+    pub auth_method: String,
     pub account_hint: Option<String>,
     pub quote_level: Option<String>,
     pub packages: Vec<String>,
@@ -315,6 +359,7 @@ impl Default for ConnectionStatus {
         Self {
             connected: false,
             state: "disconnected".into(),
+            auth_method: "none".into(),
             account_hint: None,
             quote_level: None,
             packages: Vec::new(),
@@ -399,4 +444,45 @@ pub struct LiveSnapshot {
     pub bars: Vec<Bar>,
     pub chain: ChainSnapshot,
     pub surface: SurfaceSnapshot,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OAuthStartRequest, OAuthStatus};
+
+    #[test]
+    fn oauth_client_id_validation_accepts_provider_ids() {
+        assert!(
+            OAuthStartRequest {
+                client_id: "client-123_abc:v1".into(),
+            }
+            .validate()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn oauth_client_id_validation_rejects_empty_or_unsafe_values() {
+        assert!(
+            OAuthStartRequest {
+                client_id: "  ".into()
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            OAuthStartRequest {
+                client_id: "client id".into(),
+            }
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn oauth_status_never_contains_a_token_field() {
+        let json = serde_json::to_value(OAuthStatus::default()).unwrap();
+        assert!(json.get("access_token").is_none());
+        assert_eq!(json["status"], "idle");
+    }
 }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -32,6 +32,10 @@ curl -fsS -X POST "$BASE_URL/api/strategy/analyze" -H 'Content-Type: application
 curl -fsS "$BASE_URL/api/audit/records?limit=5" | jq -e 'type == "array"' >/dev/null
 CONNECTION="$(curl -fsS "$BASE_URL/api/connection")"
 jq -e '.credential_storage == "process_memory_only"' <<<"$CONNECTION" >/dev/null
+OAUTH_STATUS="$(curl -fsS "$BASE_URL/api/oauth/status")"
+jq -e '.status == "idle" and (.authorization_url == null) and (.error == null)' <<<"$OAUTH_STATUS" >/dev/null
+OAUTH_INVALID_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$BASE_URL/api/oauth/start" -H 'Content-Type: application/json' --data '{"client_id":"bad client id"}')"
+[[ "$OAUTH_INVALID_STATUS" == "400" ]]
 if [[ "$(jq -r '.connected' <<<"$CONNECTION")" == "true" ]]; then
   STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/api/live/snapshot")"
   [[ "$STATUS" == "200" || "$STATUS" == "409" ]]


### PR DESCRIPTION
## Summary
- add Longbridge OAuth 2.0 browser authorization with an in-memory token store
- expose flow status and authorization URL without returning or persisting tokens
- add OAuth controls and polling to the live connection drawer while keeping API Key fallback
- document provider authorization boundaries and add API/smoke/unit coverage

## Validation
- `cargo test --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `npm run build`
- `./scripts/publication-check.sh`
- `./scripts/smoke-test.sh http://127.0.0.1:7311`
- `node scripts/browser-smoke.mjs http://127.0.0.1:7311`
- OAuth lifecycle: start with a test Client ID, verify URL/no token, cancel, verify `idle`

The live provider consent step still requires a real Longbridge OAuth Client ID and user authorization.
