### PR TITLE
security: harden release dependency gates

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -29,7 +29,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Verify reviewed advisory remains unreachable
+        run: |
+          active_tree="$(cargo tree --manifest-path rust-backend/Cargo.toml --locked --target all -i rkyv 2>/dev/null)"
+          if [[ -n "$active_tree" ]]; then
+            printf 'rkyv entered the active dependency tree:\n%s\n' "$active_tree" >&2
+            exit 1
+          fi
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: rust-backend
+          # rust_decimal lists rkyv as optional metadata, but no target enables it.
+          # The preceding reachability guard fails before this exception can hide
+          # a future activation. See SECURITY.md.
+          ignore: RUSTSEC-2026-0235

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and releases use semantic versioning after the public API stabilizes.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-13
+
 ### Added
 
 - Independent Option Workstation repository structure.
@@ -29,7 +31,5 @@ and releases use semantic versioning after the public API stabilizes.
   exception with an all-target dependency-reachability check.
 - Updated the transitive `nanoid` dependency past `GHSA-2v37-7h3g-55p8`.
 - Publication-time private-path, market-data, oversized-file, and secret scans.
-
-## [0.1.0] - Unreleased
 
 Initial public preview. No compatibility guarantee is provided before 1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and releases use semantic versioning after the public API stabilizes.
   typed-confirmation gates.
 - Local Longbridge OAuth compatibility patch upgrades the transitive TLS stack
   past RUSTSEC-2026-0098, RUSTSEC-2026-0099, and RUSTSEC-2026-0104.
+- RustSec CI now guards the reviewed lockfile-only `RUSTSEC-2026-0235`
+  exception with an all-target dependency-reachability check.
+- Updated the transitive `nanoid` dependency past `GHSA-2v37-7h3g-55p8`.
 - Publication-time private-path, market-data, oversized-file, and secret scans.
 
 ## [0.1.0] - Unreleased

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,25 @@ Running the server on a shared host, reverse proxy, or public network without
 additional authentication and isolation is outside the supported threat model.
 See `docs/THREAT_MODEL.md`.
 
+## Reviewed Dependency Advisories
+
+`RUSTSEC-2026-0235` currently appears in `Cargo.lock` because `rust_decimal`
+declares `rkyv 0.7` as an optional dependency. Option Workstation does not
+enable that feature, and `cargo tree --target all -i rkyv` is empty. The
+security workflow therefore ignores this lockfile-only advisory only after a
+separate reachability guard verifies that `rkyv` remains absent from every
+active target dependency tree. If a future dependency enables it, CI fails
+before the exception is applied.
+
+Run the same gate locally with:
+
+```bash
+./scripts/rustsec-check.sh
+```
+
+This exception must be removed when the upstream dependency graph no longer
+records the affected unsupported series.
+
 ## Out of Scope
 
 The following are not security vulnerabilities by themselves:

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -13,8 +13,9 @@
 - [ ] Apache-2.0 license choice is confirmed by the copyright owner.
 - [ ] `NOTICE` and `THIRD_PARTY_NOTICES.md` are current.
 - [ ] Dependency licenses pass review.
-- [ ] `cargo audit` reports zero vulnerabilities; all informational warnings
-      and vendored patches have been reviewed.
+- [ ] `./scripts/rustsec-check.sh` reports zero unreviewed vulnerabilities; all
+      documented exceptions, informational warnings, and vendored patches have
+      been reviewed.
 - [ ] The local Longbridge OAuth patch is still necessary, or has been removed
       in favor of an equivalent secure upstream release.
 - [ ] No provider market data or restricted screenshots are tracked.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1648,9 +1648,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/scripts/publication-check.sh
+++ b/scripts/publication-check.sh
@@ -10,6 +10,7 @@ token_prefix="hk_""m_"
 private_key_marker="PRIVATE"" KEY"
 publication_pattern="(${users_prefix}[^/[:space:]]+|${token_prefix}[A-Za-z0-9._-]{20,}|-----BEGIN [A-Z ]*${private_key_marker}-----)"
 if rg --hidden \
+  --glob '!.git' \
   --glob '!.git/**' \
   --glob '!frontend/node_modules/**' \
   --glob '!frontend/dist/**' \
@@ -76,7 +77,7 @@ else
 fi
 
 if cargo audit --version >/dev/null 2>&1; then
-  cargo audit --file rust-backend/Cargo.lock
+  ./scripts/rustsec-check.sh
 else
   printf 'cargo-audit is not installed; CI will run the RustSec audit.\n' >&2
 fi

--- a/scripts/rustsec-check.sh
+++ b/scripts/rustsec-check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$ROOT/rust-backend/Cargo.toml"
+LOCKFILE="$ROOT/rust-backend/Cargo.lock"
+REVIEWED_ADVISORY="RUSTSEC-2026-0235"
+
+# rust_decimal declares rkyv 0.7 as an optional dependency, so Cargo.lock records
+# it even though no Option Workstation target enables it. Never allow the audit
+# exception to survive if that changes.
+active_tree="$(cargo tree --manifest-path "$MANIFEST" --locked --target all -i rkyv 2>/dev/null)"
+if [[ -n "$active_tree" ]]; then
+  printf 'RustSec check failed: rkyv entered the active dependency tree:\n%s\n' "$active_tree" >&2
+  exit 1
+fi
+
+printf 'Verified that rkyv is absent from the active dependency tree on all targets.\n'
+cargo audit --file "$LOCKFILE" --ignore "$REVIEWED_ADVISORY"


### PR DESCRIPTION
## Summary

- fix the publication scan so linked worktrees do not expose their `.git` pointer as a false private-path finding
- update the transitive `nanoid` lock entry past `GHSA-2v37-7h3g-55p8`
- document `RUSTSEC-2026-0235` as a lockfile-only reviewed exception and fail CI if `rkyv` ever enters the active dependency tree
- align the release checklist and changelog with the executable security gate

## Security rationale

`rust_decimal` declares `rkyv 0.7` as an optional dependency, which causes it to remain in `Cargo.lock`. Option Workstation does not enable the feature: `cargo tree --locked --target all -i rkyv` is empty. The new gate verifies that invariant before the audit exception is applied. A future activation therefore fails CI instead of being hidden.

## Verification

- `make check`
- `make security`
- `npm ci && npm run build`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `./scripts/rustsec-check.sh`

## Risk and rollback

This does not change runtime analytics or order behavior. Rollback is the single commit in this PR; removing the RustSec exception without also removing the lockfile-only dependency will restore the existing audit issue.
